### PR TITLE
MixinRegistrySyncManagerのremapを有効化

### DIFF
--- a/src/main/java/dev/uten2c/strobo/mixin/MixinRegistrySyncManager.java
+++ b/src/main/java/dev/uten2c/strobo/mixin/MixinRegistrySyncManager.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MixinRegistrySyncManager {
 
     // FabricAPIのレジストリー同期機能を無効化
-    @Inject(method = "sendPacket(Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/server/network/ServerPlayerEntity;)V", at = @At("HEAD"), cancellable = true, remap = false)
+    @Inject(method = "sendPacket(Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/server/network/ServerPlayerEntity;)V", at = @At("HEAD"), cancellable = true)
     private static void disable(MinecraftServer server, ServerPlayerEntity player, CallbackInfo ci) {
         ci.cancel();
     }


### PR DESCRIPTION
jarファイル化した後サーバーでロードすると`sendPacket(Lnet/minecraft/serv...`の部分が正常にリマップされずMixin時にクラッシュしてしまうため`remap = false`を削除しました

[クラッシュ時ログ(pastebin)](https://pastebin.com/k3Jbyvar)